### PR TITLE
Copy/Paste bug

### DIFF
--- a/Sources/FitDataProtocol/Messages/WeatherConditionsMessage.swift
+++ b/Sources/FitDataProtocol/Messages/WeatherConditionsMessage.swift
@@ -248,7 +248,7 @@ open class WeatherConditionsMessage: FitMessage {
         guard fields.isEmpty == false else { return.failure(self.encodeNoPropertiesAvailable()) }
         
         let defMessage = DefinitionMessage(architecture: .little,
-                                           globalMessageNumber: WeatherAlertMessage.globalMessageNumber(),
+                                           globalMessageNumber: WeatherConditionsMessage.globalMessageNumber(),
                                            fields: UInt8(fields.count),
                                            fieldDefinitions: fields,
                                            developerFieldDefinitions: [DeveloperFieldDefinition]())


### PR DESCRIPTION
When trying to add a `WeatherConditionsMessage` the SDK throws the following error

> Wrong DefinitionMessage used for Encoding FitDataProtocol.WeatherConditionsMessage

It looks like the class which defines the globalMessageNumber was copied incorrectly.